### PR TITLE
Update chains.yml

### DIFF
--- a/config/chains.yml
+++ b/config/chains.yml
@@ -1197,8 +1197,8 @@ mainnet:
       color: "#bb2d40"
       explorer:
         name: "Agoric"
-        url: "https://bigdipper.live/agoric"
-        icon: "/logos/explorers/bigdipper.png"
+        url: "https://atomscan.com/agoric"
+        icon: "/logos/explorers/mintscan.png"
         block_path: "/blocks/{block}"
         address_path: "/accounts/{address}"
         contract_path: "/accounts/{address}"


### PR DESCRIPTION
This pull request removes the BigDipper explorer from the Agoric chain configuration, in accordance with the sunset announcement detailed in the BigDipper tweet (https://twitter.com/bigdipperlive/status/1766162059690119486).