### PR TITLE
chore: remove grain-wei

### DIFF
--- a/config/assets.yml
+++ b/config/assets.yml
@@ -3439,37 +3439,6 @@ mainnet:
         address: "0x91c415FEcD651F11D24aC4b72Ed08dbEb9868D43"
       axelarnet:
         ibc_denom: "gdx-wei"
-  grain-wei:
-    denom: "grain-wei"
-    native_chain: "ethereum"
-    name: "Granary"
-    symbol: "GRAIN"
-    decimals: 18
-    image: "/logos/assets/grain.svg"
-    addresses:
-      ethereum:
-        address: "0xF88Baf18FAB7e330fa0C4F83949E23F52FECECce"
-      binance:
-        address: "0x8F87A7d376821c7B2658a005aAf190Ec778BF37A"
-        symbol: "axlGRAIN"
-      polygon:
-        address: "0x8429d0AFade80498EAdb9919E41437A14d45A00B"
-        symbol: "axlGRAIN"
-      avalanche:
-        address: "0x9df4Ac62F9E435DbCD85E06c990a7f0ea32739a9"
-        symbol: "axlGRAIN"
-      fantom:
-        address: "0x02838746d9E1413E07EE064fcBada57055417f21"
-        symbol: "axlGRAIN"
-      arbitrum:
-        address: "0x80bB30D62a16e1F2084dEAE84dc293531c3AC3A1"
-        symbol: "axlGRAIN"
-      optimism:
-        address: "0xfD389Dc9533717239856190F42475d3f263a270d"
-        symbol: "axlGRAIN"
-      axelarnet:
-        ibc_denom: "grain-wei"
-        symbol: "axlGRAIN"
   knc-wei:
     denom: "knc-wei"
     native_chain: "ethereum"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axelarscan-api",
-  "version": "0.0.112",
+  "version": "0.0.113",
   "description": "Axelarscan API",
   "main": "index.js",
   "scripts": {

--- a/terraform/devnet-amplifier/variables.tf.example
+++ b/terraform/devnet-amplifier/variables.tf.example
@@ -45,7 +45,7 @@ variable "log_level" {
 
 variable "app_version" {
   description = "App version, same as docker image version"
-  default     = "0.0.112"
+  default     = "0.0.113"
   validation {
     error_message = "Must be valid semantic version. $Major.$Minor.$Patch"
     condition     = can(regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$", var.app_version))

--- a/terraform/devnet-verifiers/variables.tf.example
+++ b/terraform/devnet-verifiers/variables.tf.example
@@ -45,7 +45,7 @@ variable "log_level" {
 
 variable "app_version" {
   description = "App version, same as docker image version"
-  default     = "0.0.112"
+  default     = "0.0.113"
   validation {
     error_message = "Must be valid semantic version. $Major.$Minor.$Patch"
     condition     = can(regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$", var.app_version))

--- a/terraform/mainnet/variables.tf.example
+++ b/terraform/mainnet/variables.tf.example
@@ -45,7 +45,7 @@ variable "log_level" {
 
 variable "app_version" {
   description = "App version, same as docker image version"
-  default     = "0.0.112"
+  default     = "0.0.113"
   validation {
     error_message = "Must be valid semantic version. $Major.$Minor.$Patch"
     condition     = can(regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$", var.app_version))

--- a/terraform/stagenet/variables.tf.example
+++ b/terraform/stagenet/variables.tf.example
@@ -45,7 +45,7 @@ variable "log_level" {
 
 variable "app_version" {
   description = "App version, same as docker image version"
-  default     = "0.0.112"
+  default     = "0.0.113"
   validation {
     error_message = "Must be valid semantic version. $Major.$Minor.$Patch"
     condition     = can(regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$", var.app_version))

--- a/terraform/testnet/variables.tf.example
+++ b/terraform/testnet/variables.tf.example
@@ -45,7 +45,7 @@ variable "log_level" {
 
 variable "app_version" {
   description = "App version, same as docker image version"
-  default     = "0.0.112"
+  default     = "0.0.113"
   validation {
     error_message = "Must be valid semantic version. $Major.$Minor.$Patch"
     condition     = can(regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$", var.app_version))


### PR DESCRIPTION
## Description
The TVL of $GRAIN is showing as 0. There is a `grain-wei` configuration on axelarscan-api indicating it as a gateway asset, which was previously set in the S3 config but seems to have been removed. Axelarscan generally relies on the S3 config; however, if an asset is not available there but is present in the Axelarscan API config, it includes the asset using the config presenting on the API end. Therefore, in this case, the API includes the `grain-wei` asset listed in the Axelarscan API config.

### Slack thread
https://interoplabs.slack.com/archives/C035KBHNP8A/p1731357865870319

## Action
 This PR removes the asset (outdated config) on axelarscan-api.
 
 ## Jira Ticket
https://axelarnetwork.atlassian.net/browse/AXE-6520