### PR TITLE
Grant Lambda permissions to create and write logs

### DIFF
--- a/terraform/mainnet/main.tf
+++ b/terraform/mainnet/main.tf
@@ -78,8 +78,8 @@ resource "aws_iam_role" "lambda_role" {
               "logs:CreateLogStream",
               "logs:PutLogEvents"
             ]
-            Effect   = "Deny"
-            Resource = "*"
+            Effect   = "Allow"
+            Resource = "arn:aws:logs:us-east-2:${var.aws_account}:log-group:/aws/lambda/${var.package_name}-${var.environment}:*"
           },
         ]
         Version = "2012-10-17"


### PR DESCRIPTION
Summary
This PR updates the lambda_execution_policy to allow the Lambda function to create and write logs to CloudWatch. Previously, the policy had a Deny effect on log actions, which could prevent the Lambda function from logging properly.

Changes
Changed Effect: Deny to Effect: Allow for log-related actions.

Scoped Resource to the specific Lambda log group (/aws/lambda/${var.package_name}-${var.environment}) in us-east-2.

Why?
This fix ensures that the Lambda function can properly create and write logs to CloudWatch, improving observability and debugging capabilities.