### PR TITLE
chore: update filecoin mainnet api to v2

### DIFF
--- a/config/chains.yml
+++ b/config/chains.yml
@@ -344,11 +344,7 @@ mainnet:
         address: "0xe432150cce91c13a887f7D836923d5597adD8E31"
       endpoints:
         rpc:
-          - "https://filfox.info/rpc/v1"
-          - "https://api.chain.love/rpc/v1"
-          - "https://filecoin.chainup.net"
-          - "https://rpc.ankr.com/filecoin"
-          - "https://api.node.glif.io"
+          - "https://api.chain.love/rpc/v2"
       native_token:
         name: "Filecoin"
         symbol: "FIL"


### PR DESCRIPTION
* Add new filecoin mainnet api (https://api.chain.love/rpc/v2).
* Remove old filecoin mainnet apis.