### PR TITLE
Replace Blastapi Endpoints

### DIFF
--- a/config/chains.yml
+++ b/config/chains.yml
@@ -40,9 +40,9 @@ mainnet:
         address: "0x304acf330bbE08d1e512eefaa92F6a57871fD895"
       endpoints:
         rpc:
-          - "https://bsc-mainnet.public.blastapi.io"
           - "https://api.zan.top/bsc-mainnet"
           - "https://bsc-rpc.publicnode.com"
+          # - "https://bsc-mainnet.public.blastapi.io"
           # - "https://bsc-dataseed1.defibit.io"
           # - "https://bsc-mainnet.nodereal.io/v1/64a9df0874fb4a93b9d0a3849de012d3"
           # - "https://1rpc.io/bnb"
@@ -98,9 +98,9 @@ mainnet:
         address: "0x5029C0EFf6C34351a0CEc334542cDb22c7928f78"
       endpoints:
         rpc:
-          - "https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc"
           - "https://avalanche-c-chain-rpc.publicnode.com"
           - "https://1rpc.io/avax/c"
+          # - "https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -125,11 +125,11 @@ mainnet:
         address: "0x304acf330bbE08d1e512eefaa92F6a57871fD895"
       endpoints:
         rpc:
-          - "https://fantom-mainnet.public.blastapi.io"
           - "https://fantom-rpc.publicnode.com"
           - "https://rpc3.fantom.network"
           - "https://rpc2.fantom.network"
           - "https://rpc.fantom.network"
+          # - "https://fantom-mainnet.public.blastapi.io"
       native_token:
         name: "Fantom"
         symbol: "FTM"
@@ -155,8 +155,8 @@ mainnet:
       endpoints:
         rpc:
           - "https://rpc.api.moonbeam.network"
-          - "https://moonbeam.public.blastapi.io"
           - "https://1rpc.io/glmr"
+          # - "https://moonbeam.public.blastapi.io"
       native_token:
         name: "Moonbeam"
         symbol: "GLMR"
@@ -183,9 +183,9 @@ mainnet:
         rpc:
           - "https://arb1.lava.build"
           - "https://endpoints.omniatech.io/v1/arbitrum/one/public"
-          - "https://arbitrum-one.public.blastapi.io"
           - "https://arbitrum-mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
           - "https://1rpc.io/arb"
+          # - "https://arbitrum-one.public.blastapi.io"
       native_token:
         name: "Ethereum"
         symbol: "ETH"
@@ -264,7 +264,8 @@ mainnet:
       endpoints:
         rpc:
           - "https://rpc.mantle.xyz"
-          - "https://mantle-mainnet.public.blastapi.io"
+          - "https://mantle-rpc.publicnode.com"
+          # - "https://mantle-mainnet.public.blastapi.io"
       native_token:
         name: "Mantle"
         symbol: "MNT"
@@ -502,7 +503,7 @@ mainnet:
         rpc:
           - "https://rpc.blast.io"
           - "https://blast-rpc.publicnode.com"
-          - "https://blastl2-mainnet.public.blastapi.io"
+          # - "https://blastl2-mainnet.public.blastapi.io"
       native_token:
         name: "Ethereum"
         symbol: "ETH"
@@ -2520,7 +2521,7 @@ testnet:
           - "https://data-seed-prebsc-2-s1.bnbchain.org:8545"
           - "https://data-seed-prebsc-1-s2.bnbchain.org:8545"
           - "https://bsc-testnet.blockpi.network/v1/rpc/public"
-          - "https://bsc-testnet.public.blastapi.io"
+          # - "https://bsc-testnet.public.blastapi.io"
       native_token:
         name: "BNB"
         symbol: "BNB"
@@ -2571,7 +2572,7 @@ testnet:
       endpoints:
         rpc:
           - "https://api.avax-test.network/ext/bc/C/rpc"
-          - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
+          # - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -2597,7 +2598,7 @@ testnet:
       endpoints:
         rpc:
           - "https://rpc.testnet.fantom.network"
-          - "https://fantom-testnet.public.blastapi.io"
+          # - "https://fantom-testnet.public.blastapi.io"
       native_token:
         name: "Fantom"
         symbol: "FTM"
@@ -2624,7 +2625,7 @@ testnet:
         rpc:
           - "https://rpc.api.moonbase.moonbeam.network"
           - "https://rpc.testnet.moonbeam.network"
-          - "https://moonbase-alpha.public.blastapi.io"
+          # - "https://moonbase-alpha.public.blastapi.io"
       native_token:
         name: "Dev"
         symbol: "DEV"
@@ -4218,7 +4219,7 @@ testnet:
       endpoints:
         rpc:
           - "https://api.avax-test.network/ext/bc/C/rpc"
-          - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
+          # - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -4559,7 +4560,7 @@ stagenet:
           - "https://data-seed-prebsc-2-s1.bnbchain.org:8545"
           - "https://data-seed-prebsc-1-s2.bnbchain.org:8545"
           - "https://bsc-testnet.blockpi.network/v1/rpc/public"
-          - "https://bsc-testnet.public.blastapi.io"
+          # - "https://bsc-testnet.public.blastapi.io"
       native_token:
         name: "BNB"
         symbol: "BNB"
@@ -4610,7 +4611,7 @@ stagenet:
       endpoints:
         rpc:
           - "https://api.avax-test.network/ext/bc/C/rpc"
-          - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
+          # - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -4636,7 +4637,8 @@ stagenet:
       endpoints:
         rpc:
           - "https://rpc.testnet.fantom.network"
-          - "https://fantom-testnet.public.blastapi.io"
+          - "https://fantom-testnet-rpc.publicnode.com"
+          # - "https://fantom-testnet.public.blastapi.io"
       native_token:
         name: "Fantom"
         symbol: "FTM"
@@ -4663,7 +4665,7 @@ stagenet:
         rpc:
           - "https://rpc.api.moonbase.moonbeam.network"
           - "https://rpc.testnet.moonbeam.network"
-          - "https://moonbase-alpha.public.blastapi.io"
+          # - "https://moonbase-alpha.public.blastapi.io"
       native_token:
         name: "Dev"
         symbol: "DEV"
@@ -4997,7 +4999,7 @@ stagenet:
       endpoints:
         rpc:
           - "https://api.avax-test.network/ext/bc/C/rpc"
-          - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
+          # - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -5360,7 +5362,7 @@ devnet-amplifier:
       endpoints:
         rpc:
           - "https://api.avax-test.network/ext/bc/C/rpc"
-          - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
+          # - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -5485,7 +5487,8 @@ devnet-amplifier:
       endpoints:
         rpc:
           - "https://api.avax-test.network/ext/bc/C/rpc"
-          - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
+          - "https://avalanche-fuji.drpc.org"
+          # - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -5514,7 +5517,7 @@ devnet-amplifier:
       endpoints:
         rpc:
           - "https://api.avax-test.network/ext/bc/C/rpc"
-          - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
+          # - "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc"
       native_token:
         name: "Avalanche"
         symbol: "AVAX"
@@ -5641,8 +5644,8 @@ devnet-amplifier:
       chain_name: "starknet-devnet-v1"
       endpoints:
         rpc:
-          - "https://starknet-sepolia.public.blastapi.io"
           - "https://rpc.starknet-testnet.lava.build"
+          # - "https://starknet-sepolia.public.blastapi.io"
       native_token:
         name: "Ethereum"
         symbol: "ETH"
@@ -5663,8 +5666,8 @@ devnet-amplifier:
       chain_name: "starknet-devnet-v2"
       endpoints:
         rpc:
-          - "https://starknet-sepolia.public.blastapi.io"
           - "https://rpc.starknet-testnet.lava.build"
+          # - "https://starknet-sepolia.public.blastapi.io"
       native_token:
         name: "Ethereum"
         symbol: "ETH"


### PR DESCRIPTION
Blastapi are shutting down at the end of October. We're removing these endpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes BlastAPI RPC URLs across environments and adds alternative public RPCs where available in config/chains.yml.
> 
> - **config/chains.yml**:
>   - **Mainnet (EVM)**: Comment out `*.public.blastapi.io` RPCs for `binance`, `avalanche`, `fantom`, `moonbeam`, `arbitrum`, `blast`; add `mantle-rpc.publicnode.com` for `mantle`.
>   - **Testnet/Stagenet (EVM)**: Comment out `BlastAPI` RPCs for `binance`, `avalanche`, `fantom`, `moonbeam`; add `fantom-testnet-rpc.publicnode.com` and `avalanche-fuji.drpc.org` (Fuji); keep/adjust other existing RPCs.
>   - **Amplifier/Devnet**:
>     - Comment out `BlastAPI` RPCs for Avalanche-related entries and Starknet devnets; keep `rpc.starknet-testnet.lava.build`.
>     - Minor non-functional whitespace fix at `ton` explorer `transaction_path`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8116d5c229e63410d960ef612121e80aa19025c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->