### PR TITLE
chore: rotate blastapi rpc

### DIFF
--- a/config/chains.yml
+++ b/config/chains.yml
@@ -502,7 +502,7 @@ mainnet:
         rpc:
           - "https://rpc.blast.io"
           - "https://blast-rpc.publicnode.com"
-          - "https://blast-sepolia.drpc.org"
+          - "https://blast.drpc.org"
       native_token:
         name: "Ethereum"
         symbol: "ETH"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces BlastAPI RPC URLs with drpc.org endpoints across multiple chains in config/chains.yml (mainnet, testnet, stagenet, devnet).
> 
> - **Config (`config/chains.yml`)**:
>   - **Mainnet EVM**:
>     - Swap BlastAPI RPCs to `*.drpc.org` for `binance`, `avalanche`, `fantom`, `moonbeam`, `arbitrum`, `mantle`, `blast`.
>   - **Testnet EVM**:
>     - Replace BlastAPI RPCs with `*.drpc.org` for `binance` (testnet), `avalanche` (Fuji), `fantom`, `moonbeam`.
>   - **Stagenet EVM**:
>     - Replace BlastAPI RPCs with `*.drpc.org` for `binance` (testnet), `avalanche` (Fuji), `fantom`, `moonbeam`.
>   - **Devnet/Amplifier**:
>     - Update Starknet devnet RPCs from BlastAPI to `starknet-sepolia.drpc.org` (v1 and v2).
>     - Replace Avalanche Fuji BlastAPI RPCs with `avalanche-fuji.drpc.org` in several amplifier sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 260b95558c4c644cd89fccb57cf89c9c88781a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->