### PR TITLE
OCSI-73 chore: add arc testnet

### DIFF
--- a/config/chains.json
+++ b/config/chains.json
@@ -5177,6 +5177,40 @@
           "transaction_path": "/tx/{tx}"
         }
       },
+      "arc-8": {
+        "chain_id": 5042002,
+        "chain_name": "arc-8",
+        "gateway": {
+          "address": "0xAfde45488D741a946E2376aDf5cf94F6a2918F48"
+        },
+        "multisig_prover": {
+          "address": "axelar1nsjl6hldse4agnjf9pm29hjetyvaxgwm2638z3qd27d32hsqygyqtsluqj"
+        },
+        "voting_verifier": {
+          "address": "axelar1qxyyfs4jynsmtu2ajjh4lmz2a9drzr6e7gzf2wcz4nc8qt96mlyqk9f6s4"
+        },
+        "endpoints": {
+          "rpc": ["https://rpc.testnet.arc.network"]
+        },
+        "native_token": {
+          "name": "USDC",
+          "symbol": "USDC",
+          "decimals": 18
+        },
+        "name": "Arc",
+        "short_name": "USDC",
+        "image": "/logos/chains/arc.svg",
+        "color": "#2775ca",
+        "explorer": {
+          "name": "Arc Testnet Explorer",
+          "url": "https://testnet.arcscan.app",
+          "icon": "/logos/explorers/arc.png",
+          "block_path": "/block/{block}",
+          "address_path": "/address/{address}",
+          "contract_path": "/token/{address}",
+          "transaction_path": "/tx/{tx}"
+        }
+      },
       "monad-3": {
         "chain_id": 10143,
         "chain_name": "monad-3",

--- a/config/chains.json
+++ b/config/chains.json
@@ -5198,7 +5198,7 @@
           "decimals": 18
         },
         "name": "Arc",
-        "short_name": "USDC",
+        "short_name": "ARC",
         "image": "/logos/chains/arc.svg",
         "color": "#2775ca",
         "explorer": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Configuration-only change that registers a new testnet chain; main risk is incorrect addresses/endpoints or explorer paths causing connectivity or UI/link issues.
> 
> **Overview**
> Adds a new `testnet` EVM chain entry for **Arc testnet** (`arc-8`) in `config/chains.json`, including its `chain_id`, RPC endpoint, gateway/multisig/voting verifier addresses, native token metadata, and explorer/linking configuration (name, logo, color).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09dc4cff04d62ab51225c96d4c84a3d2e1f07457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->