### PR TITLE
feat: add solana-stagenet-3 config

### DIFF
--- a/config/chains.json
+++ b/config/chains.json
@@ -6290,6 +6290,39 @@
           "contract_path": "/token/{address}",
           "transaction_path": "/tx/{tx}"
         }
+      },
+      "solana-stagenet-3": {
+        "chain_name": "solana-stagenet-3",
+        "gateway": {
+          "address": "gtwYHfHHipAoj8Hfp3cGr3vhZ8f3UtptGCQLqjBkaSZ"
+        },
+        "multisig_prover": {
+          "address": "axelar1swvhlmhh4ken5sja0upjmrttzl20ptuppyk4k8gx73qpqqu5dqvslqvcje"
+        },
+        "voting_verifier": {
+          "address": "axelar10hnv3yfzn5fxrefqa0rmw6n37n3vpgfceh0z24y2yzdqumvrch6qhvwfyq"
+        },
+        "endpoints": {
+          "rpc": ["https://api.testnet.solana.com"]
+        },
+        "native_token": {
+          "name": "Solana",
+          "symbol": "SOL",
+          "decimals": 9
+        },
+        "name": "Solana",
+        "short_name": "SOL",
+        "image": "/logos/chains/solana.svg",
+        "color": "#8d4df7",
+        "explorer": {
+          "name": "Solana Testnet Explorer",
+          "url": "https://explorer.solana.com",
+          "icon": "/logos/explorers/solana.png",
+          "block_path": "/block/{block}?cluster=testnet",
+          "address_path": "/address/{address}?cluster=testnet",
+          "contract_path": "/address/{address}?cluster=testnet",
+          "transaction_path": "/tx/{tx}?cluster=testnet"
+        }
       }
     }
   },


### PR DESCRIPTION
This PR adds stagenet deployment `solana-stagenet-3` to Axelarscan. Deployment data has been taken from PR https://github.com/axelarnetwork/axelar-contract-deployments/pull/1349.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but incorrect addresses/endpoints could cause the new stagenet chain to display broken links or fetch data from the wrong network.
> 
> **Overview**
> Adds a new `stagenet` amplifier chain entry, `solana-stagenet-3`, including gateway/multisig/voting verifier addresses, Solana testnet RPC endpoint, native token metadata, and explorer link templates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdce1d78ae519e2cd94190f632a402f0ff5f041b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->