### PR TITLE
feat: add solana testnet config

### DIFF
--- a/config/chains.json
+++ b/config/chains.json
@@ -5345,6 +5345,39 @@
           "contract_path": "/token/{address}",
           "transaction_path": "/tx/{tx}"
         }
+      },
+      "solana": {
+        "chain_name": "solana",
+        "gateway": {
+          "address": "gtwJ8LWDRWZpbvCqp8sDeTgy3GSyuoEsiaKC8wSXJqq"
+        },
+        "multisig_prover": {
+          "address": "axelar1xdtjwhenmy80wckuntd2npd3zeqayy0q0l5dfy48g6wmu3p48pgqknnc9g"
+        },
+        "voting_verifier": {
+          "address": "axelar19gut3kvqf57gnu5ylq474qfgk4gg5ly89cs5kk4mde688lc5adsq6qyz4h"
+        },
+        "endpoints": {
+          "rpc": ["https://api.devnet.solana.com"]
+        },
+        "native_token": {
+          "name": "Solana",
+          "symbol": "SOL",
+          "decimals": 9
+        },
+        "name": "Solana",
+        "short_name": "SOL",
+        "image": "/logos/chains/solana.svg",
+        "color": "#8d4df7",
+        "explorer": {
+          "name": "Solana",
+          "url": "https://explorer.solana.com",
+          "icon": "/logos/explorers/solana.png",
+          "block_path": "/block/{block}?cluster=devnet",
+          "address_path": "/address/{address}?cluster=devnet",
+          "contract_path": "/address/{address}?cluster=devnet",
+          "transaction_path": "/tx/{tx}?cluster=devnet"
+        }
       }
     }
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, config-only change that adds a new chain entry; main risk is misconfigured addresses/endpoints causing Solana testnet/devnet integrations to fail or display incorrect explorer links.
> 
> **Overview**
> Adds a new `testnet.amplifier.solana` entry in `config/chains.json`, including gateway/prover/verifier addresses, Solana devnet RPC endpoint, native token metadata (SOL), and Solana explorer URL/path templates (devnet cluster params).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92867c12cb034dc83b27a61a79b1360888288a42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->