### PR TITLE
chore: deprecate zkstack-memento (devnet-amplifier) and memento-demo (testnet)

### DIFF
--- a/config/chains.json
+++ b/config/chains.json
@@ -5311,6 +5311,42 @@
           "transaction_path": "/tx/{tx}"
         }
       },
+      "memento-demo": {
+        "deprecated": true,
+        "chain_id": 2129,
+        "chain_name": "memento-demo",
+        "maintainer_id": "memento-demo",
+        "gateway": {
+          "address": "0x51bC41E390E7d8271ef3594713C14ab933E37001"
+        },
+        "multisig_prover": {
+          "address": "axelar13s3xyvcjpetwdfyc9q2hh9nc3hdvf7cvtkh33qk0g8adjjjgrk6qeacv67"
+        },
+        "voting_verifier": {
+          "address": "axelar1uekdelqqxxuq5e6jxttlaxrhq3aq2ksn45h9lvtljc6hayeqe95qss5s6v"
+        },
+        "endpoints": {
+          "rpc": []
+        },
+        "native_token": {
+          "name": "Ethereum",
+          "symbol": "ETH",
+          "decimals": 18
+        },
+        "name": "Memento",
+        "short_name": "MEMENTO",
+        "image": "/logos/chains/memento.svg",
+        "color": "#d06435",
+        "explorer": {
+          "name": "Memento Testnet Explorer",
+          "url": "https://private-explorer.memento.zeeve.online",
+          "icon": "/logos/explorers/memento.png",
+          "block_path": "/block/{block}",
+          "address_path": "/address/{address}",
+          "contract_path": "/token/{address}",
+          "transaction_path": "/tx/{tx}"
+        }
+      },
       "solana": {
         "chain_name": "solana",
         "gateway": {
@@ -6956,6 +6992,34 @@
           "block_path": "/block/{block}",
           "address_path": "/address/{address}",
           "contract_path": "/address/{address}",
+          "transaction_path": "/tx/{tx}"
+        }
+      },
+      "zkstack-memento": {
+        "deprecated": true,
+        "chain_id": 12052024,
+        "chain_name": "zkstack-memento",
+        "endpoints": {
+          "rpc": [
+            "https://test-rpc.mementoblockchain.com/IRkghvI3FfEArEJMr4zC/rpc"
+          ]
+        },
+        "native_token": {
+          "name": "Ethereum",
+          "symbol": "ETH",
+          "decimals": 18
+        },
+        "name": "Memento",
+        "short_name": "MMT",
+        "image": "/logos/chains/memento.svg",
+        "color": "#0072bc",
+        "explorer": {
+          "name": "Memento",
+          "url": "https://test-explorer.mementoblockchain.com",
+          "icon": "/logos/explorers/memento.png",
+          "block_path": "/block/{block}",
+          "address_path": "/address/{address}",
+          "contract_path": "/token/{address}",
           "transaction_path": "/tx/{tx}"
         }
       },

--- a/config/chains.json
+++ b/config/chains.json
@@ -5311,41 +5311,6 @@
           "transaction_path": "/tx/{tx}"
         }
       },
-      "memento-demo": {
-        "chain_id": 2129,
-        "chain_name": "memento-demo",
-        "maintainer_id": "memento-demo",
-        "gateway": {
-          "address": "0x51bC41E390E7d8271ef3594713C14ab933E37001"
-        },
-        "multisig_prover": {
-          "address": "axelar13s3xyvcjpetwdfyc9q2hh9nc3hdvf7cvtkh33qk0g8adjjjgrk6qeacv67"
-        },
-        "voting_verifier": {
-          "address": "axelar1uekdelqqxxuq5e6jxttlaxrhq3aq2ksn45h9lvtljc6hayeqe95qss5s6v"
-        },
-        "endpoints": {
-          "rpc": []
-        },
-        "native_token": {
-          "name": "Ethereum",
-          "symbol": "ETH",
-          "decimals": 18
-        },
-        "name": "Memento",
-        "short_name": "MEMENTO",
-        "image": "/logos/chains/memento.svg",
-        "color": "#d06435",
-        "explorer": {
-          "name": "Memento Testnet Explorer",
-          "url": "https://private-explorer.memento.zeeve.online",
-          "icon": "/logos/explorers/memento.png",
-          "block_path": "/block/{block}",
-          "address_path": "/address/{address}",
-          "contract_path": "/token/{address}",
-          "transaction_path": "/tx/{tx}"
-        }
-      },
       "solana": {
         "chain_name": "solana",
         "gateway": {
@@ -6991,33 +6956,6 @@
           "block_path": "/block/{block}",
           "address_path": "/address/{address}",
           "contract_path": "/address/{address}",
-          "transaction_path": "/tx/{tx}"
-        }
-      },
-      "zkstack-memento": {
-        "chain_id": 12052024,
-        "chain_name": "zkstack-memento",
-        "endpoints": {
-          "rpc": [
-            "https://test-rpc.mementoblockchain.com/IRkghvI3FfEArEJMr4zC/rpc"
-          ]
-        },
-        "native_token": {
-          "name": "Ethereum",
-          "symbol": "ETH",
-          "decimals": 18
-        },
-        "name": "Memento",
-        "short_name": "MMT",
-        "image": "/logos/chains/memento.svg",
-        "color": "#0072bc",
-        "explorer": {
-          "name": "Memento",
-          "url": "https://test-explorer.mementoblockchain.com",
-          "icon": "/logos/explorers/memento.png",
-          "block_path": "/block/{block}",
-          "address_path": "/address/{address}",
-          "contract_path": "/token/{address}",
           "transaction_path": "/tx/{tx}"
         }
       },


### PR DESCRIPTION
## Changes

Mark chain entries for deprecated chains in `config/chains.json` as deprecated:

| Chain | Environment |
|-------|----------------|
| `zkstack-memento` | `devnet-amplifier.amplifier` |
| `memento-demo` | `testnet.amplifier` |

Part of chain deprecation effort. The corresponding EDS config changes are in axelarnetwork/axelar-eds#5736.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only deprecation flags on non-production test/dev amplifier chains; no runtime logic changes in this diff.
> 
> **Overview**
> Marks **`memento-demo`** (testnet amplifier) and **`zkstack-memento`** (devnet-amplifier amplifier) as deprecated in `config/chains.json` by adding `"deprecated": true` on each entry, following the same pattern as other retired chains (e.g. testnet `terra-2`).
> 
> The full chain metadata (IDs, gateway, prover/verifier addresses, RPC, explorer) stays in place so existing references can still resolve while consumers that honor `deprecated` can hide or de-prioritize these networks. This aligns with the broader Memento chain deprecation effort and related EDS config work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb81b9d94757d518cc7bf41a5d59b2054a35470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->