### PR TITLE
chore: mark secret as deprecated

### DIFF
--- a/config/chains.json
+++ b/config/chains.json
@@ -910,6 +910,7 @@
         "prefix_chain_ids": ["kaiyo-"]
       },
       "secret-snip": {
+        "deprecated": true,
         "chain_id": "secret-4",
         "chain_name": "secret-snip",
         "endpoints": {
@@ -946,6 +947,7 @@
         "prefix_chain_ids": ["secret-"]
       },
       "secret": {
+        "deprecated": true,
         "chain_id": "secret-4",
         "chain_name": "secret",
         "endpoints": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only metadata on two chain entries; no logic or endpoint changes.
> 
> **Overview**
> Marks both mainnet Cosmos entries for Secret Network—`secret` and `secret-snip`—as deprecated in `config/chains.json` by setting **`deprecated`: true**, matching how other retired chains (e.g. Centrifuge, Flow) are flagged.
> 
> No LCD endpoints, chain IDs, or other metadata are changed; only the deprecation flag is added so consumers can treat these routes as legacy without removing config yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a73c21152fc34c6bc3572e7fc0505f32570345f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->