### PR TITLE
feat: show cosmos IBC channels on resources/chains

### DIFF
--- a/methods/index.js
+++ b/methods/index.js
@@ -30,14 +30,14 @@ const {
 } = require('./interchain');
 const {
   getMethods,
-  getChains,
+  getChainsWithIBCChannels,
   getAssets,
   getITSAssets,
   getContracts,
 } = require('../utils/config');
 
 const METHODS = {
-  getChains: () => getChains(),
+  getChains: () => getChainsWithIBCChannels(),
   getAssets: () => getAssets(),
   getITSAssets: () => getITSAssets(),
   getContracts: () => getContracts(),

--- a/test/getChains.js
+++ b/test/getChains.js
@@ -7,8 +7,8 @@ const { getChains } = require('../methods');
 
 module.exports = () => {
   describe('getChains', () => {
-    it('Should receive list of chain data', () => {
-      const response = getChains();
+    it('Should receive list of chain data', async () => {
+      const response = await getChains();
 
       response.forEach(d => {
         expect(d).to.be.an('object');

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -201,6 +201,10 @@ interface IBCChannels {
   toAxelar?: IBCChannelEnd;
 }
 
+// the axelar hub itself has no IBC channels to itself, so it must never be
+// auto-deprecated by the no-channels rule below
+const AXELAR_HUB_CHAIN_ID = 'axelarnet';
+
 // enrich cosmos chains with their IBC channels (from/to Axelar) from the axelar s3 config
 const getChainsWithIBCChannels = async (
   types?: ChainType | ChainType[],
@@ -211,21 +215,30 @@ const getChainsWithIBCChannels = async (
   // get ibc channels from axelar s3 chains config
   const s3ChainsConfig = await getAxelarS3ChainsConfig(env);
 
-  // map ibc channels by chain id
+  // map ibc channels by chain id (only when a channel id is actually set)
   const ibcByChainId: Record<string, IBCChannels> = {};
   for (const [chain, value] of Object.entries(s3ChainsConfig?.chains || {})) {
     const ibc = (value as { config?: { ibc?: IBCChannels } })?.config?.ibc;
-    if (ibc?.fromAxelar || ibc?.toAxelar) {
+    if (ibc?.fromAxelar?.channelId || ibc?.toAxelar?.channelId) {
       ibcByChainId[getChainByS3ConfigChain(chain)] = ibc;
     }
   }
 
-  // attach ibc channels to cosmos chains
-  return chainsData.map(chain =>
-    chain.chain_type === 'cosmos' && ibcByChainId[chain.id]
-      ? { ...chain, ibc: ibcByChainId[chain.id] }
-      : chain
-  );
+  return chainsData.map(chain => {
+    if (chain.chain_type !== 'cosmos') return chain;
+
+    const ibc = ibcByChainId[chain.id];
+
+    // attach ibc channels when available
+    if (ibc) return { ...chain, ibc };
+
+    // otherwise auto-deprecate the chain (except the axelar hub itself)
+    if (chain.id !== AXELAR_HUB_CHAIN_ID) {
+      return { ...chain, deprecated: true, no_inflation: true, no_tvl: true };
+    }
+
+    return chain;
+  });
 };
 
 const getChainData = (

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -191,6 +191,43 @@ const getChains = (
     .filter(chain => !chain.disabled);
 };
 
+interface IBCChannelEnd {
+  portId?: string;
+  channelId?: string;
+}
+
+interface IBCChannels {
+  fromAxelar?: IBCChannelEnd;
+  toAxelar?: IBCChannelEnd;
+}
+
+// enrich cosmos chains with their IBC channels (from/to Axelar) from the axelar s3 config
+const getChainsWithIBCChannels = async (
+  types?: ChainType | ChainType[],
+  env: Environment = ENVIRONMENT
+): Promise<ProcessedChain[]> => {
+  const chainsData = getChains(types, env);
+
+  // get ibc channels from axelar s3 chains config
+  const s3ChainsConfig = await getAxelarS3ChainsConfig(env);
+
+  // map ibc channels by chain id
+  const ibcByChainId: Record<string, IBCChannels> = {};
+  for (const [chain, value] of Object.entries(s3ChainsConfig?.chains || {})) {
+    const ibc = (value as { config?: { ibc?: IBCChannels } })?.config?.ibc;
+    if (ibc?.fromAxelar || ibc?.toAxelar) {
+      ibcByChainId[getChainByS3ConfigChain(chain)] = ibc;
+    }
+  }
+
+  // attach ibc channels to cosmos chains
+  return chainsData.map(chain =>
+    chain.chain_type === 'cosmos' && ibcByChainId[chain.id]
+      ? { ...chain, ibc: ibcByChainId[chain.id] }
+      : chain
+  );
+};
+
 const getChainData = (
   chain: string,
   types: ChainType | ChainType[],
@@ -539,6 +576,7 @@ export {
   getAxelarS3Config,
   getChainData,
   getChains,
+  getChainsWithIBCChannels,
   getContracts,
   getCustomTVLConfig,
   getEndpoints,


### PR DESCRIPTION
Display the inbound (to Axelar) and outbound (from Axelar) IBC channel ids for cosmos chains on the chains resource cards, sourced from the enriched getChains API response.

This PR needs to be merged and deployed before https://github.com/axelarnetwork/axelarscan-ui/pull/388

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cosmos chains appear in the API (including automatic deprecation) and makes getChains async, which can affect callers and TVL/inflation visibility for chains missing S3 IBC config.
> 
> **Overview**
> The public **`getChains`** method now returns an **async** payload built by **`getChainsWithIBCChannels`**, which merges Axelar S3 chain config IBC **`fromAxelar` / `toAxelar`** channel ids onto **cosmos** chains for resources/chains UI.
> 
> Cosmos chains **without** any configured IBC channel are **auto-marked deprecated** with **`no_inflation`** and **`no_tvl`**, except the **`axelarnet`** hub. The **`getChains`** test was updated to **`await`** the response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e084561fe7f17ece06accca86446027be9fccd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->