### PR TITLE
config: deprecate moonbeam (all envs) + testnet fantom & scroll-sepolia

### DIFF
--- a/config/chains.json
+++ b/config/chains.json
@@ -169,6 +169,7 @@
         }
       },
       "moonbeam": {
+        "deprecated": true,
         "chain_id": 1284,
         "chain_name": "Moonbeam",
         "maintainer_id": "moonbeam",
@@ -3081,6 +3082,7 @@
         }
       },
       "fantom": {
+        "deprecated": true,
         "chain_id": 4002,
         "chain_name": "Fantom",
         "maintainer_id": "fantom",
@@ -3113,6 +3115,7 @@
         }
       },
       "moonbeam": {
+        "deprecated": true,
         "chain_id": 1287,
         "chain_name": "Moonbeam",
         "maintainer_id": "moonbeam",
@@ -3394,6 +3397,7 @@
         }
       },
       "scroll": {
+        "deprecated": true,
         "chain_id": 534351,
         "chain_name": "scroll",
         "maintainer_id": "scroll",
@@ -5575,6 +5579,7 @@
         }
       },
       "fantom": {
+        "deprecated": true,
         "chain_id": 4002,
         "chain_name": "Fantom",
         "maintainer_id": "fantom",
@@ -5607,6 +5612,7 @@
         }
       },
       "moonbeam": {
+        "deprecated": true,
         "chain_id": 1287,
         "chain_name": "Moonbeam",
         "maintainer_id": "moonbeam",


### PR DESCRIPTION
Mark moonbeam deprecated on mainnet, testnet and stagenet (chain_ids 1284/1287).

Also bundle in chains that are already deactivated on the nexus but were still un-flagged here: testnet fantom and stagenet fantom (both Fantom-testnet, chain_id 4002) and scroll-sepolia (testnet scroll, chain_id 534351).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only metadata flags with no logic or endpoint changes; aligns chain registry with existing nexus deactivations.
> 
> **Overview**
> Sets **`"deprecated": true`** on several chain entries in `config/chains.json` so config matches chains already turned off on nexus.
> 
> **Moonbeam** is marked deprecated in every environment: mainnet (1284), testnet (1287), and the duplicate testnet/stagenet blocks. **Fantom testnet** (4002) gets the flag on testnet and stagenet. **Scroll Sepolia** (534351) is deprecated on testnet.
> 
> No RPC, gateway, or explorer fields are removed—only the deprecation flag is added, consistent with other retired chains in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d45d8ad818720f0af17c64a84d162adbff08ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->